### PR TITLE
Petit coup de jeune au README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
-#Citron Inc
-Ceci est une page d'exemple qui sert de fil rouge à mon tutoriel sur Sass & Compass sur Zeste de Savoir.
+# Citron Inc
+Ceci est une page d'exemple qui sert de fil rouge à [mon tutoriel sur Sass & Compass](https://zestedesavoir.com/contenus/beta/672/reprenez-le-controle-de-vos-feuilles-de-style-avec-sass/) sur [Zeste de Savoir](https://zestedesavoir.com/).
 
-##Téléchargement
-Pour récupérer l'ensemble du projet (feuille de style, page HTML et images), cliquez sur Download ZIP, dans la barre latérale de droite.
+## Téléchargement
+Pour récupérer l'ensemble du projet (feuille de style, page HTML et images), cliquez sur “Download ZIP” dans la liste déroulante sur la page d’accueil du projet :
 
-##Source des images
-Voici les sources des différentes images libres de droits utilisées dans l'exemple :
+![Download ZIP](https://user-images.githubusercontent.com/15378830/30023133-90fb3d8e-916e-11e7-8394-5c94b68fa803.png)
 
- - http://www.stockvault.net/photo/121598/cocktail-
- - http://www.stockvault.net/photo/144079/lemons
- - http://www.stockvault.net/photo/144905/lemon
- - http://www.stockvault.net/photo/152458/lemons
- - http://www.stockvault.net/photo/116317/splashing-lemon
- - http://www.stockvault.net/photo/115248/red-chilli
+
+## Source des images
+
+Voici les sources des différentes images libres de droits utilisées dans l'exemple :
+
+ - [Cocktail](http://www.stockvault.net/photo/121598/cocktail-)
+ - [Plusieurs citrons](http://www.stockvault.net/photo/144079/lemons)
+ - [Un seul citron](http://www.stockvault.net/photo/144905/lemon)
+ - [Citrons dans l’arbre](http://www.stockvault.net/photo/152458/lemons)
+ - [Citron plongeant dans un verre](http://www.stockvault.net/photo/116317/splashing-lemon)
+ - [Piment rouge](http://www.stockvault.net/photo/115248/red-chilli)
  - *Nosferatu le vampire*, F. W. Murnau (1922)
  - Mascotte Clem' par [MaxRoyo](http://maxroyo.com)


### PR DESCRIPTION
Notez que l’interface de GitHub a changé entre temps, le bouton “Download ZIP” a changé.

**[Voir le README.md rénové](https://github.com/motet-a/CitronInc/blob/df3b44a6971274371d933ed0e3c2f8606c80392c/README.md)**